### PR TITLE
Potential fix for code scanning alert no. 3: Incomplete URL substring sanitization

### DIFF
--- a/tests/test_synthesis.py
+++ b/tests/test_synthesis.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 from pathlib import Path
+import re
 from unittest.mock import AsyncMock, patch
+from urllib.parse import urlparse
 
 import pytest
 
@@ -303,7 +305,12 @@ class TestPaperGenerator:
         assert "2301.00001" in refs
         assert "Paper One" in refs
         assert "et al." in refs
-        assert "arxiv.org" in refs
+        urls = re.findall(r"https?://[^\s)>\]]+", refs)
+        hosts = [urlparse(u).hostname for u in urls]
+        assert any(
+            h == "arxiv.org" or (h is not None and h.endswith(".arxiv.org"))
+            for h in hosts
+        )
 
     def test_build_references_empty(self, llm_client):
         gen = PaperGenerator(llm_client)

--- a/tests/test_synthesis.py
+++ b/tests/test_synthesis.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-from pathlib import Path
 import re
+from pathlib import Path
 from unittest.mock import AsyncMock, patch
 from urllib.parse import urlparse
 


### PR DESCRIPTION
Potential fix for [https://github.com/timlawrenz/ratiocinator/security/code-scanning/3](https://github.com/timlawrenz/ratiocinator/security/code-scanning/3)

Use URL parsing in the test instead of substring matching.  
Specifically in `tests/test_synthesis.py`, update `test_build_references_with_papers` so it extracts URLs from `refs`, parses them with `urllib.parse.urlparse`, and asserts at least one parsed hostname is exactly `arxiv.org` or a valid subdomain of it (for robustness).

Changes needed:
- Add `import re` and `from urllib.parse import urlparse` near existing imports.
- Replace `assert "arxiv.org" in refs` with parsed-host assertions based on extracted `http(s)` URLs.

This preserves test intent (“references include ArXiv links”) while avoiding incomplete URL substring sanitization.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
