### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/timlawrenz/ratiocinator/security/code-scanning/2](https://github.com/timlawrenz/ratiocinator/security/code-scanning/2)

Add an explicit `permissions` block at the workflow root so it applies to both `lint` and `test` jobs without changing behavior. The minimal required permission here is `contents: read` (needed by `actions/checkout`). No new imports, methods, or dependencies are needed.

Edit `.github/workflows/ci.yml` by inserting:

```yml
permissions:
  contents: read
```

between the `on:` trigger section and `jobs:` (or anywhere at root level). This preserves current functionality while constraining token scope.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
